### PR TITLE
Add curl to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN chmod +x /opt/microsoft/powershell/pwsh
 
 FROM mcr.microsoft.com/dotnet/runtime-deps:6.0
 
-RUN apt update && apt install -y jq=1.6-2.1
+RUN apt update && apt install -y jq=1.6-2.1 curl
 
 # copy exes from the builder container
 COPY --from=deps /bin/kubectl /bin/kubectl


### PR DESCRIPTION
We need curl in the agent tools base so we can download the Helm values migrator plugin.

