### PR TITLE
Add Kubernetes 1.32.0 and bump helm

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,19 +1,20 @@
 {
     "tools": {
         "kubectl": [
+            "1.32.0",
             "1.31.4",
             "1.30.8",
             "1.29.12"
         ],
         "helm": [
-            "3.16.3"
+            "3.16.4"
         ],
         "powershell": [
             "7.4.6"
         ]
     },
     "latest": "1.30",
-    "revisionHash": "FYZKxo",
+    "revisionHash": "TArC80",
     "deprecations": {
         "1.26": {
             "latestTag": "1.26@sha256:a0892db7be9d668eceba2ce0c56ed82b2a58ff205ffea27a98e40825143b63f0"


### PR DESCRIPTION
Kubernetes [1.32](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.32.md) was released on 2024-12-11, so adding a container image for it
Helm [3.16.4](https://github.com/helm/helm/releases/tag/v3.16.4) was released on 2024-12-17, so bumping :)