### PR TITLE
Update Kubernetes versions

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,10 +1,10 @@
 {
     "tools": {
         "kubectl": [
-            "1.32.0",
-            "1.31.4",
-            "1.30.8",
-            "1.29.12"
+            "1.32.1",
+            "1.31.5",
+            "1.30.9",
+            "1.29.13"
         ],
         "helm": [
             "3.16.4"
@@ -14,7 +14,7 @@
         ]
     },
     "latest": "1.30",
-    "revisionHash": "TArC80",
+    "revisionHash": "RIjcCa",
     "deprecations": {
         "1.26": {
             "latestTag": "1.26@sha256:a0892db7be9d668eceba2ce0c56ed82b2a58ff205ffea27a98e40825143b63f0"


### PR DESCRIPTION
Bumps k8s version to the latest

There is a new `3.17.0` of Helm, but it was only released 4 days ago, so I think it's prudent to wait a week or two to make sure there is no major issues.