### PR TITLE
Update Helm to 3.17.1

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -7,14 +7,14 @@
             "1.29.13"
         ],
         "helm": [
-            "3.16.4"
+            "3.17.1"
         ],
         "powershell": [
             "7.4.6"
         ]
     },
     "latest": "1.30",
-    "revisionHash": "RIjcCa",
+    "revisionHash": "xuPpCD",
     "deprecations": {
         "1.26": {
             "latestTag": "1.26@sha256:a0892db7be9d668eceba2ce0c56ed82b2a58ff205ffea27a98e40825143b63f0"


### PR DESCRIPTION
Patch version bump.

This supersedes PR #13 (sorry @eddymoulton  😁 )
 