### PR TITLE
Update versions and add K8s 1.33 build

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,19 +1,20 @@
 {
     "tools": {
         "kubectl": [
-            "1.32.2",
-            "1.31.6",
-            "1.30.10"
+            "1.33.1",
+            "1.32.5",
+            "1.31.9",
+            "1.30.13"
         ],
         "helm": [
             "3.17.3"
         ],
         "powershell": [
-            "7.5.0"
+            "7.5.1"
         ]
     },
     "latest": "1.31",
-    "revisionHash": "EIcoCY",
+    "revisionHash": "bU487h",
     "deprecations": {
         "1.26": {
             "latestTag": "1.26@sha256:a0892db7be9d668eceba2ce0c56ed82b2a58ff205ffea27a98e40825143b63f0"


### PR DESCRIPTION
Does not include the upgrade to Helm 3.18.0 due to a significant [regression](https://github.com/helm/helm/issues/30878)