### PR TITLE
chore: bump k8s version in versions.json

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,32 +1,32 @@
 {
-    "tools": {
-        "kubectl": [
-            "1.33.1",
-            "1.32.5",
-            "1.31.9",
-            "1.30.13"
-        ],
-        "helm": [
-            "3.17.3"
-        ],
-        "powershell": [
-            "7.5.1"
-        ]
+  "tools": {
+    "kubectl": [
+      "1.33.1",
+      "1.32.5",
+      "1.31.9",
+      "1.30.13"
+    ],
+    "helm": [
+      "3.17.3"
+    ],
+    "powershell": [
+      "7.5.1"
+    ]
+  },
+  "latest": "1.33",
+  "revisionHash": "bU487h",
+  "deprecations": {
+    "1.26": {
+      "latestTag": "1.26@sha256:a0892db7be9d668eceba2ce0c56ed82b2a58ff205ffea27a98e40825143b63f0"
     },
-    "latest": "1.31",
-    "revisionHash": "bU487h",
-    "deprecations": {
-        "1.26": {
-            "latestTag": "1.26@sha256:a0892db7be9d668eceba2ce0c56ed82b2a58ff205ffea27a98e40825143b63f0"
-        },
-        "1.27": {
-            "latestTag": "1.27@sha256:9d1ce87c37a33582bd3bb0b2e2d54d7a6bc0e71d659a1132acd3893c9645a507"
-        },
-        "1.28": {
-            "latestTag": "1.28@sha256:c2a7c7d230b2c959c4228f0860d5d6dca143a38fa037911fc5dd0319a0cf1ed0"
-        },
-        "1.29": {
-            "latestTag": "1.29@sha256:a47d5221bf5ba679b03c5c9cf05d9569e5074f5897f8f92b6cf435bca7e6f2ae"
-        }
+    "1.27": {
+      "latestTag": "1.27@sha256:9d1ce87c37a33582bd3bb0b2e2d54d7a6bc0e71d659a1132acd3893c9645a507"
+    },
+    "1.28": {
+      "latestTag": "1.28@sha256:c2a7c7d230b2c959c4228f0860d5d6dca143a38fa037911fc5dd0319a0cf1ed0"
+    },
+    "1.29": {
+      "latestTag": "1.29@sha256:a47d5221bf5ba679b03c5c9cf05d9569e5074f5897f8f92b6cf435bca7e6f2ae"
     }
+  }
 }


### PR DESCRIPTION
# Background
Clusters running k8s 1.32 or 1.33 were using `latest` since we never updated the version, which forced the image pull policy to be `Always`. This change should fix this issue, especially since we support 1.33 and 1.32 with our kubectl versions.

# Pre-requisites

- [ ] I have regenerated the `revisionHash` when updating `versions.json` - NOT REQUIRED
- [x] I am adding support for a brand-new Kubernetes release. I have updated the `KnownLatestContainerTags` in [Tentacle](https://github.com/OctopusDeploy/OctopusTentacle/blob/main/source/Octopus.Tentacle/Kubernetes/KubernetesPodContainerResolver.cs#L28) and released an updated Kubernetes agent.
