### PR TITLE
Add "I have updated the `latest` version..." to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,4 +5,6 @@
 # Pre-requisites
 
 - [ ] I have regenerated the `revisionHash` when updating `versions.json`
-- [ ] I am adding support for a brand-new Kubernetes release. I have updated the `KnownLatestContainerTags` in [Tentacle](https://github.com/OctopusDeploy/OctopusTentacle/blob/main/source/Octopus.Tentacle/Kubernetes/KubernetesPodContainerResolver.cs#L28) and released an updated Kubernetes agent.
+- [ ] I am adding support for a brand-new Kubernetes release.
+    - [ ] I have updated the `KnownLatestContainerTags` in [Tentacle](https://github.com/OctopusDeploy/OctopusTentacle/blob/main/source/Octopus.Tentacle/Kubernetes/KubernetesPodContainerResolver.cs#L28) and released an updated Kubernetes agent.
+    - [ ] I have updated the `latest` version in `versions.json`


### PR DESCRIPTION
# Background
Add additional pull request pre-requisite to ensure everything is updated when adding new k8s versions.

We previously had missed updating the `latest` value when adding new supported versions of k8s - this was causing consumers on newer k8s version to always pull the `latest` tag, which has implications around registry rate limiting.

# Pre-requisites

- [ ] I have regenerated the `revisionHash` when updating `versions.json`
- [ ] I am adding support for a brand-new Kubernetes release. I have updated the `KnownLatestContainerTags` in [Tentacle](https://github.com/OctopusDeploy/OctopusTentacle/blob/main/source/Octopus.Tentacle/Kubernetes/KubernetesPodContainerResolver.cs#L28) and released an updated Kubernetes agent.
