### PR TITLE
Update Kubernetes and Helm versions

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,19 +1,19 @@
 {
   "tools": {
     "kubectl": [
-      "1.33.3",
-      "1.32.7",
-      "1.31.11"
+      "1.33.4",
+      "1.32.8",
+      "1.31.12"
     ],
     "helm": [
-      "3.18.4"
+      "3.18.5"
     ],
     "powershell": [
       "7.5.2"
     ]
   },
   "latest": "1.33",
-  "revisionHash": "Pp8pqT",
+  "revisionHash": "bkTlYI",
   "deprecations": {
     "1.26": {
       "latestTag": "1.26@sha256:a0892db7be9d668eceba2ce0c56ed82b2a58ff205ffea27a98e40825143b63f0"


### PR DESCRIPTION
# Background

New versions are released

# Pre-requisites

- [x] I have regenerated the `revisionHash` when updating `versions.json`
- [ ] I am adding support for a brand-new Kubernetes release.
    - [ ] I have updated the `KnownLatestContainerTags` in [Tentacle](https://github.com/OctopusDeploy/OctopusTentacle/blob/main/source/Octopus.Tentacle/Kubernetes/KubernetesPodContainerResolver.cs#L28) and released an updated Kubernetes agent.
    - [ ] I have updated the `latest` version in `versions.json`
