### PR TITLE
Add k8s 1.34 and update other versions

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,19 +1,20 @@
 {
   "tools": {
     "kubectl": [
-      "1.33.4",
-      "1.32.8",
-      "1.31.12"
+      "1.34.1",
+      "1.33.5",
+      "1.32.9",
+      "1.31.13"
     ],
     "helm": [
-      "3.18.5"
+      "3.18.6"
     ],
     "powershell": [
-      "7.5.2"
+      "7.5.3"
     ]
   },
   "latest": "1.33",
-  "revisionHash": "bkTlYI",
+  "revisionHash": "bvBxSk",
   "deprecations": {
     "1.26": {
       "latestTag": "1.26@sha256:a0892db7be9d668eceba2ce0c56ed82b2a58ff205ffea27a98e40825143b63f0"


### PR DESCRIPTION
# Background

1.34 has been released.

There is also updates to all other versions :)

# Pre-requisites

- [x] I have regenerated the `revisionHash` when updating `versions.json`
- [x] I am adding support for a brand-new Kubernetes release.
    - [x] I have updated the `KnownLatestContainerTags` in [Tentacle](https://github.com/OctopusDeploy/OctopusTentacle/blob/main/source/Octopus.Tentacle/Kubernetes/KubernetesPodContainerResolver.cs#L28) and released an updated Kubernetes agent.
    - [ ] I have updated the `latest` version in `versions.json`
