### PR TITLE
Update Helm to 3.20.2

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -6,14 +6,14 @@
       "1.33.10"
     ],
     "helm": [
-      "3.20.1"
+      "3.20.2"
     ],
     "powershell": [
       "7.6.0"
     ]
   },
   "latest": "1.34",
-  "revisionHash": "JnTEWU",
+  "revisionHash": "lUNwly",
   "deprecations": {
     "1.26": {
       "latestTag": "1.26@sha256:a0892db7be9d668eceba2ce0c56ed82b2a58ff205ffea27a98e40825143b63f0"


### PR DESCRIPTION
# Background

<!-- Why does this PR exist? -->

# Pre-requisites

- [x] I have regenerated the `revisionHash` when updating `versions.json`
- [ ] I am adding support for a brand-new Kubernetes release.
    - [ ] I have updated the `KnownLatestContainerTags` in [Tentacle](https://github.com/OctopusDeploy/OctopusTentacle/blob/main/source/Octopus.Tentacle/Kubernetes/KubernetesPodContainerResolver.cs#L28) and released an updated Kubernetes agent.
    - [ ] I have updated the `latest` version in `versions.json`
