### PR TITLE
Update PowerShell to 7.6.2

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -10,11 +10,11 @@
       "3.21.0"
     ],
     "powershell": [
-      "7.6.1"
+      "7.6.2"
     ]
   },
   "latest": "1.35",
-  "revisionHash": "FqbqFf",
+  "revisionHash": "utx1IT",
   "deprecations": {
     "1.26": {
       "latestTag": "1.26@sha256:a0892db7be9d668eceba2ce0c56ed82b2a58ff205ffea27a98e40825143b63f0"


### PR DESCRIPTION
# Background

- https://github.com/PowerShell/PowerShell/releases/tag/v7.6.2

# Pre-requisites

- [x] I have regenerated the `revisionHash` when updating `versions.json`
- [ ] I am adding support for a brand-new Kubernetes release.
    - [ ] I have updated the `KnownLatestContainerTags` in [Tentacle](https://github.com/OctopusDeploy/OctopusTentacle/blob/main/source/Octopus.Tentacle/Kubernetes/KubernetesPodContainerResolver.cs#L28) and released an updated Kubernetes agent.
    - [ ] I have updated the `latest` version in `versions.json`
