### PR TITLE
Update Helm version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN groupadd -g 999 octopus \
     && echo 'octopus:265536:65536' >> /etc/subuid \
     && echo 'octopus:265536:65536' >> /etc/subgid
 
-RUN apt update && apt install -y jq=1.6-2.1+deb11u1 curl
+RUN apt update && apt install -y jq=1.6-2.1+deb11u2 curl
 
 # copy exes from the builder container
 COPY --from=deps /bin/kubectl /bin/kubectl

--- a/versions.json
+++ b/versions.json
@@ -7,14 +7,14 @@
       "1.33.12"
     ],
     "helm": [
-      "3.21.0"
+      "3.21.1"
     ],
     "powershell": [
       "7.6.2"
     ]
   },
   "latest": "1.35",
-  "revisionHash": "utx1IT",
+  "revisionHash": "gNmN8V",
   "deprecations": {
     "1.26": {
       "latestTag": "1.26@sha256:a0892db7be9d668eceba2ce0c56ed82b2a58ff205ffea27a98e40825143b63f0"


### PR DESCRIPTION
# Background

Helm 3.21.1 has been released. Also, we need to bump `jq` to the latest security release

# Pre-requisites

- [x] I have regenerated the `revisionHash` when updating `versions.json`
- [ ] I am adding support for a brand-new Kubernetes release.
    - [ ] I have updated the `KnownLatestContainerTags` in [Tentacle](https://github.com/OctopusDeploy/OctopusTentacle/blob/main/source/Octopus.Tentacle/Kubernetes/KubernetesPodContainerResolver.cs#L28) and released an updated Kubernetes agent.
    - [ ] I have updated the `latest` version in `versions.json`
