### PR TITLE
Upgrade to runtime-deps:8.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN groupadd -g 999 octopus \
     && echo 'octopus:265536:65536' >> /etc/subuid \
     && echo 'octopus:265536:65536' >> /etc/subgid
 
-RUN apt update && apt install -y jq=1.6-2.1+deb11u2 curl
+RUN apt update && apt install -y jq=1.6-2.1+deb12u1 curl
 
 # copy exes from the builder container
 COPY --from=deps /bin/kubectl /bin/kubectl

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN mkdir -p /opt/microsoft/powershell
 RUN tar zxf /tmp/powershell.tar.gz -C /opt/microsoft/powershell
 RUN chmod +x /opt/microsoft/powershell/pwsh
 
-FROM mcr.microsoft.com/dotnet/runtime-deps:6.0
+FROM mcr.microsoft.com/dotnet/runtime-deps:8.0
 
 # Take UID/GID 999 for ourselves before installing software-properties-common. In debian 12+ it sets up systemd-journal with GID 999
 # but we want to keep 999 from older versions of our Octopus container; customers assign permissions to it.

--- a/versions.json
+++ b/versions.json
@@ -14,7 +14,7 @@
     ]
   },
   "latest": "1.35",
-  "revisionHash": "gNmN8V",
+  "revisionHash": "HTWfTT",
   "deprecations": {
     "1.26": {
       "latestTag": "1.26@sha256:a0892db7be9d668eceba2ce0c56ed82b2a58ff205ffea27a98e40825143b63f0"


### PR DESCRIPTION
# Background

We are basing the image on `runtime-deps:6.0`, which is based on Debian 11.

All the executed tooling (Calamari) is now .NET 8.0 so we can upgrade this to `runtime-deps:8.0` which is Debian 12.

Also, should fix #49 (did so in our testing)

# Pre-requisites

- [x] I have regenerated the `revisionHash` when updating `versions.json`
- [ ] I am adding support for a brand-new Kubernetes release.
    - [ ] I have updated the `KnownLatestContainerTags` in [Tentacle](https://github.com/OctopusDeploy/OctopusTentacle/blob/main/source/Octopus.Tentacle/Kubernetes/KubernetesPodContainerResolver.cs#L28) and released an updated Kubernetes agent.
    - [ ] I have updated the `latest` version in `versions.json`
