### PR TITLE
Update versions for helm and powershell

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -7,14 +7,14 @@
       "1.33.12"
     ],
     "helm": [
-      "3.21.1"
+      "3.21.2"
     ],
     "powershell": [
-      "7.6.2"
+      "7.6.3"
     ]
   },
   "latest": "1.35",
-  "revisionHash": "HTWfTT",
+  "revisionHash": "tT9UBk",
   "deprecations": {
     "1.26": {
       "latestTag": "1.26@sha256:a0892db7be9d668eceba2ce0c56ed82b2a58ff205ffea27a98e40825143b63f0"


### PR DESCRIPTION
# Background

Helm: [3.21.2](https://github.com/helm/helm/releases/tag/v3.21.2)
PowerShell: [7.6.3](https://github.com/PowerShell/PowerShell/releases/tag/v7.6.3)

# Pre-requisites

- [x] I have regenerated the `revisionHash` when updating `versions.json`
- [ ] I am adding support for a brand-new Kubernetes release.
    - [ ] I have updated the `KnownLatestContainerTags` in [Tentacle](https://github.com/OctopusDeploy/OctopusTentacle/blob/main/source/Octopus.Tentacle/Kubernetes/KubernetesPodContainerResolver.cs#L28) and released an updated Kubernetes agent.
    - [ ] I have updated the `latest` version in `versions.json`
