### PR TITLE
Update kubectl versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN groupadd -g 999 octopus \
     && echo 'octopus:265536:65536' >> /etc/subuid \
     && echo 'octopus:265536:65536' >> /etc/subgid
 
-RUN apt update && apt install -y jq=1.6-2.1+deb12u1 curl
+RUN apt update && apt install -y jq=1.6-2.1+deb12u2 curl
 
 # copy exes from the builder container
 COPY --from=deps /bin/kubectl /bin/kubectl

--- a/versions.json
+++ b/versions.json
@@ -1,10 +1,10 @@
 {
   "tools": {
     "kubectl": [
-      "1.36.1",
-      "1.35.5",
-      "1.34.8",
-      "1.33.12"
+      "1.36.2",
+      "1.35.6",
+      "1.34.9",
+      "1.33.13"
     ],
     "helm": [
       "3.21.2"
@@ -14,7 +14,7 @@
     ]
   },
   "latest": "1.35",
-  "revisionHash": "tT9UBk",
+  "revisionHash": "GC0Yd7",
   "deprecations": {
     "1.26": {
       "latestTag": "1.26@sha256:a0892db7be9d668eceba2ce0c56ed82b2a58ff205ffea27a98e40825143b63f0"


### PR DESCRIPTION
# Background

Updated kubectl versions

# Pre-requisites

- [x] I have regenerated the `revisionHash` when updating `versions.json`
- [ ] I am adding support for a brand-new Kubernetes release.
    - [ ] I have updated the `KnownLatestContainerTags` in [Tentacle](https://github.com/OctopusDeploy/OctopusTentacle/blob/main/source/Octopus.Tentacle/Kubernetes/KubernetesPodContainerResolver.cs#L28) and released an updated Kubernetes agent.
    - [ ] I have updated the `latest` version in `versions.json`
