### PR TITLE
Update Helm & PowerShell

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -7,16 +7,16 @@
       "1.33.13"
     ],
     "helm": [
-      "4.2.2",
-      "3.21.2"
+      "4.2.3",
+      "3.21.3"
     ],
     "powershell": [
-      "7.6.3"
+      "7.6.4"
     ]
   },
   "latest": "1.35",
   "latestHelm": "3",
-  "revisionHash": "JxNPOt",
+  "revisionHash": "wdbrFp",
   "deprecations": {
     "1.26": {
       "latestTag": "1.26@sha256:a0892db7be9d668eceba2ce0c56ed82b2a58ff205ffea27a98e40825143b63f0"


### PR DESCRIPTION
# Background

Updated helm and powershell versions, and revised the revision hash.

# Pre-requisites

- [x] I have regenerated the `revisionHash` when updating `versions.json`
- [ ] I am adding support for a brand-new Kubernetes release.
    - [ ] I have updated the `KnownLatestContainerTags` in [Tentacle](https://github.com/OctopusDeploy/OctopusTentacle/blob/main/source/Octopus.Tentacle/Kubernetes/KubernetesPodContainerResolver.cs#L28) and released an updated Kubernetes agent.
    - [ ] I have updated the `latest` version in `versions.json`
